### PR TITLE
Updated Values.yaml to Remove ImagePullSecrets

### DIFF
--- a/helm-chart/values-gradle-dev.yaml
+++ b/helm-chart/values-gradle-dev.yaml
@@ -12,7 +12,7 @@ namespace: "backend-dev"
 image:
   repository: ghcr.io/sadityalal
   name: projectapp
-  tag: 1858b77
+  tag: 08b6df2
   pullPolicy: IfNotPresent
 
 # Since we use private registry we need to authenticate before pulling the image.

--- a/helm-chart/values-gradle-dev.yaml
+++ b/helm-chart/values-gradle-dev.yaml
@@ -17,8 +17,7 @@ image:
 
 # Since we use private registry we need to authenticate before pulling the image.
 # This secret will be created automatically in CICD pipeline when will deploy the application.
-imagePullSecrets:
-  name: regcd
+imagePullSecrets: []
 
 ## Update Strategy i.e. Rolling Update or Recreate
 update_strategy:

--- a/helm-chart/values-gradle-dev.yaml
+++ b/helm-chart/values-gradle-dev.yaml
@@ -12,7 +12,7 @@ namespace: "backend-dev"
 image:
   repository: ghcr.io/sadityalal
   name: projectapp
-  tag: 7f0b388
+  tag: 1858b77
   pullPolicy: IfNotPresent
 
 # Since we use private registry we need to authenticate before pulling the image.

--- a/helm-chart/values-gradle.yaml
+++ b/helm-chart/values-gradle.yaml
@@ -19,8 +19,7 @@ image:
 
 # Since we use private registry we need to authenticate before pulling the image.
 # This secret will be created automatically in CICD pipeline when will deploy the application.
-imagePullSecrets:
-  name: regcd
+imagePullSecrets: []
 
 ## Update Strategy i.e. Rolling Update or Recreate
 update_strategy:

--- a/helm-chart/values-gradle.yaml
+++ b/helm-chart/values-gradle.yaml
@@ -14,7 +14,7 @@ namespace: "backend"
 image:
   repository: ghcr.io/sadityalal
   name: projectapp
-  tag: 7f0b388
+  tag: 1858b77
   pullPolicy: IfNotPresent
 
 # Since we use private registry we need to authenticate before pulling the image.

--- a/helm-chart/values-gradle.yaml
+++ b/helm-chart/values-gradle.yaml
@@ -14,7 +14,7 @@ namespace: "backend"
 image:
   repository: ghcr.io/sadityalal
   name: projectapp
-  tag: 1858b77
+  tag: 08b6df2
   pullPolicy: IfNotPresent
 
 # Since we use private registry we need to authenticate before pulling the image.


### PR DESCRIPTION
Since ImagePullSecrets should be available on kubernetes cluster, we can always create docker-registry secret.
Right now app is available for testing, so I have made the image available publicly.